### PR TITLE
change module version constraint

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,13 +90,13 @@ here](https://github.com/tbobm/terraform-github-environments/blob/master/.github
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_github"></a> [github](#requirement\_github) | ~> 4.0 |
+| <a name="requirement_github"></a> [github](#requirement\_github) | >= 4.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_github"></a> [github](#provider\_github) | ~> 4.0 |
+| <a name="provider_github"></a> [github](#provider\_github) | >= 4.0 |
 
 ## Modules
 

--- a/versions.tf
+++ b/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     github = {
       source  = "integrations/github"
-      version = "~> 4.0"
+      version = ">= 4.0"
     }
   }
 }


### PR DESCRIPTION
from pessimistic operator to greater than operator.

integrations/github has bumped the major version of the provider
bringing in additional features.

To make this module more accessible and interoperable with other
resources in the new version of the provider, we would have to support
all upward versions until an incompatibility is identified. At which
point, we could consider updating the code to fix the incompatibilty or
add a lesser than operator if the incompatibilty cannot be resolved
within the scope of the code in the repository.
